### PR TITLE
Fixed typo in sample code

### DIFF
--- a/handover_protocol/README.md
+++ b/handover_protocol/README.md
@@ -21,7 +21,7 @@ This repo contains code for the webhook and application logic for an example Mes
 ``` js
 module.exports = {
   "PAGE_ACCESS_TOKEN": "<YOUR PAGE ACCESS TOKEN>",  
-  "VERIFY TOKEN": "YOUR WEBHOOK VERIFY TOKEN"
+  "VERIFY_TOKEN": "YOUR WEBHOOK VERIFY TOKEN"
 }  
 ```
 Alternatively, you can set the above as environment variables.


### PR DESCRIPTION
Fixed a type in env config sample section. The VERIFY_TOKEN key must have a underscore instead a space